### PR TITLE
fix: spread argv to allow multiple params to jest

### DIFF
--- a/packages/vite-jest/bin/vite-jest.js
+++ b/packages/vite-jest/bin/vite-jest.js
@@ -14,7 +14,7 @@ fs.writeFileSync(path.join(viteClientDirectory, 'package.json'), JSON.stringify(
 execa.sync('node', [
   '--experimental-vm-modules',
   jestPath,
-  process.argv.slice(2)
+  ...process.argv.slice(2)
 ], {
   stdio: 'inherit'
 })


### PR DESCRIPTION
before `vite-jest --detectOpenHandles --runInBand` would fail as 'Unrecognized option "detectOpenHandles,--runInBand".'

now multiple parameters can be passed to jest