### PR TITLE
feat: allow use in workspaces

### DIFF
--- a/packages/vite-jest/bin/vite-jest.js
+++ b/packages/vite-jest/bin/vite-jest.js
@@ -7,10 +7,6 @@ import { createRequire } from 'module'
 
 const require = createRequire(import.meta.url)
 const jestPath = require.resolve('jest/bin/jest')
-const vitePath = require.resolve('vite'); // => vite/dist/node/index.js
-
-const viteClientDirectory = path.resolve(path.dirname(vitePath), '../client');
-fs.writeFileSync(path.join(viteClientDirectory, 'package.json'), JSON.stringify({ type: "module" }))
 
 execa.sync('node', [
   '--experimental-vm-modules',

--- a/packages/vite-jest/bin/vite-jest.js
+++ b/packages/vite-jest/bin/vite-jest.js
@@ -7,8 +7,9 @@ import { createRequire } from 'module'
 
 const require = createRequire(import.meta.url)
 const jestPath = require.resolve('jest/bin/jest')
+const vitePath = require.resolve('vite'); // => vite/dist/node/index.js
 
-const viteClientDirectory = path.join(process.cwd(), './node_modules/vite/dist/client')
+const viteClientDirectory = path.resolve(path.dirname(vitePath), '../client');
 fs.writeFileSync(path.join(viteClientDirectory, 'package.json'), JSON.stringify({ type: "module" }))
 
 execa.sync('node', [

--- a/packages/vite-jest/index.js
+++ b/packages/vite-jest/index.js
@@ -26,6 +26,9 @@ export function fsPathFromId(id) {
 
 // TODO: use a createTransformer function to get rootDir
 const rootDir = process.cwd()
+// https://github.com/vitejs/vite/blob/v2.4.2/packages/vite/src/node/constants.ts#L44-L46
+const CLIENT_ENTRY = require.resolve('vite/dist/client/client.mjs')
+const ENV_ENTRY = require.resolve('vite/dist/client/env.mjs')
 
 async function processAsync(src, filepath) {
   const result = await viteServer.transformRequest(filepath)
@@ -56,9 +59,9 @@ async function processAsync(src, filepath) {
         // FIXME: Temporary workaround.
         // The root problem is that Jest can't resolve virtual files.
         // So it may be better to create on-disk placeholder files for virtual files.
-        mStr.overwrite(start, end, require.resolve('vite/dist/client/env.js'))
+        mStr.overwrite(start, end, ENV_ENTRY)
       } else if (url === '/@vite/client') {
-        mStr.overwrite(start, end, require.resolve('vite/dist/client/client.js'))
+        mStr.overwrite(start, end, CLIENT_ENTRY)
       } else if (url.startsWith('/')) {
         mStr.overwrite(start, end, path.join(rootDir, url))
       }


### PR DESCRIPTION
previously, vite-jest assumed process.cwd() would contain node_modules
in workspace environments, a parent directory may contain node_modules
now, vite-jest will work in either setup

---

my project setup looks like:

- package.json
- node_modules
- workspace-a
  - package.json

if `workspace-a/package.json` had a test script `vite-jest` and was run from the root (i.e. `npm run test --workspace workspace-a`), it would attempt to write to `workspace-a/node_modules/vite/dist/client` which did not exist. now, it will correctly write to `node_modules/vite/dist/client` even though `process.cwd()` is `workspace-a`.