### PR TITLE
Fixed react ts jest

### DIFF
--- a/examples/react-app-ts/jest.config.js
+++ b/examples/react-app-ts/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testMatch: [
     "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-    "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",
+    "<rootDir>/src/**/*.{spec,test}.{ts,tsx}",
   ],
   testEnvironment: "jest-environment-jsdom",
   moduleNameMapper: {


### PR DESCRIPTION
Related to https://github.com/sodatea/vite-jest/issues/12 and https://github.com/vitejs/vite/issues/1955

I changed `"<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",` to `"<rootDir>/src/**/*.{spec,test}.{ts,tsx}",` and now the tests are running.

![Screen Shot 2021-07-30 at 10 55 42 AM](https://user-images.githubusercontent.com/3621147/127584710-ec8dea7f-9c60-41e1-ac93-62a1db79ca84.png)

```
module.exports = {
  preset: "vite-jest",

  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
  testMatch: [
    "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
    "<rootDir>/src/**/*.{spec,test}.{ts,tsx}",
  ],
  testEnvironment: "jest-environment-jsdom",
  moduleNameMapper: {
    "\\.(css|sass|scss)$": "identity-obj-proxy",
  },
};

```